### PR TITLE
changed font family

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,7 @@ export default {
 
 <style lang="scss">
 #app {
-  font-family: Avenir, Helvetica, Arial, sans-serif;
+  font-family: Popins, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-align: center;

--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,7 @@ export default {
 
 <style lang="scss">
 #app {
-  font-family: Popins, sans-serif;
+  font-family: monospace;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-align: center;


### PR DESCRIPTION
Changed fonts from Avenir, Helvetica, Arial to Popins.
![スクリーンショット 2023-07-06 230941](https://github.com/RikitoNoto/silkroad.github.io/assets/138220177/b4702980-c904-4dd3-a043-84f23a57c5f5)
